### PR TITLE
Development

### DIFF
--- a/UBS/Editor/EditorWindow/BuildProcessEditor.cs
+++ b/UBS/Editor/EditorWindow/BuildProcessEditor.cs
@@ -384,6 +384,14 @@ namespace UBS
 				// dont show anything!
 			}
 				break;
+            
+            case EBuildStepParameterType.Boolean:
+            {
+                bool value;
+                var succeeded = bool.TryParse(pStep.mParams, out value);
+                pStep.mParams = Convert.ToString(succeeded ? EditorGUI.Toggle(r4, value) : EditorGUI.Toggle(r4, false));
+            }
+                break;
 				
 			case EBuildStepParameterType.String:
 			{

--- a/UBS/Editor/Steps/Android/KeystorePath.cs
+++ b/UBS/Editor/Steps/Android/KeystorePath.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-using System.Collections;
 using UnityEditor;
 
 namespace UBS.Android
@@ -13,7 +11,9 @@ namespace UBS.Android
 		
 		public void BuildStepStart (BuildConfiguration pConfiguration)
 		{
-			PlayerSettings.Android.keystoreName = pConfiguration.Params;
+		    var path = pConfiguration.Params.Replace("$PROJECTDIR", pConfiguration.ProjectDirectory);
+            path = path.Replace("$OUTDIR", path);
+            PlayerSettings.Android.keystoreName = path;
 		}
 		
 		public void BuildStepUpdate ()

--- a/UBS/Editor/Steps/Compiler/ClearAllCompilerFlags.cs
+++ b/UBS/Editor/Steps/Compiler/ClearAllCompilerFlags.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UBS;
+using UnityEditor;
+
+namespace UBS.Compiler
+{
+    [BuildStepDescriptionAttribute("Clears all custom compiler flags but will allow a number of defines, when exists.")]
+    [BuildStepParameterFilter(EBuildStepParameterType.None)]
+    public class ClearAllCompilerFlags : IBuildStepProvider
+    {        
+        #region IBuildStepProvider implementation
+
+        /// <summary>
+        /// System related Unity script symbol definitions. May change over time and are only used, when already included in script definition file.
+        /// </summary>
+        /// <returns>A list of all unity related script symbol definitions.</returns>
+        private static List<string> UnitySystemRelatedSymbols()
+        {
+            return new List<string>{
+                "MICRO", // micro windows store deployment
+                "1", // ?????
+                "NO_ECMASCRIPT" // IOS related IL2CPP flag
+            };
+        }
+        
+        public void BuildStepStart(BuildConfiguration pConfiguration)
+        {
+            BuildTargetGroup btg = Helpers.GroupFromBuildTarget(pConfiguration.GetCurrentBuildProcess().mPlatform);
+            string symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(btg);
+            
+            List<string> symbolsArray = new List<string>(symbols.Split(';'));
+            List<string> systemSymbols = UnitySystemRelatedSymbols();
+
+            var interesection = symbolsArray.Intersect(systemSymbols).ToArray();
+           
+            string clearedSymbols = String.Empty;
+            if (interesection.Length > 0)
+            {
+                clearedSymbols = string.Join(";", interesection);
+            }
+
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(btg, clearedSymbols);
+        }
+        
+        public void BuildStepUpdate()
+        {
+            
+        }
+        
+        public bool IsBuildStepDone()
+        {
+            return true;
+        }
+        
+        #endregion
+    }
+}

--- a/UBS/Editor/Steps/Compiler/SetCompilerFlags.cs
+++ b/UBS/Editor/Steps/Compiler/SetCompilerFlags.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UBS;
+using UnityEditor;
+
+namespace UBS.Compiler
+{
+    [BuildStepDescriptionAttribute("Overwrites the compiler script definitions inside the unity player platform specific settings.")]
+    [BuildStepParameterFilter(EBuildStepParameterType.String)]
+    public class SetCompilerFlags : IBuildStepProvider
+    {        
+        #region IBuildStepProvider implementation
+               
+        public void BuildStepStart(BuildConfiguration pConfiguration)
+        {
+            BuildTargetGroup btg = Helpers.GroupFromBuildTarget(pConfiguration.GetCurrentBuildProcess().mPlatform);            
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(btg, pConfiguration.Params);
+        }
+        
+        public void BuildStepUpdate()
+        {
+            
+        }
+        
+        public bool IsBuildStepDone()
+        {
+            return true;
+        }
+        
+        #endregion
+    }
+}

--- a/UBS/Editor/UBS/EBuildStepParameterType.cs
+++ b/UBS/Editor/UBS/EBuildStepParameterType.cs
@@ -3,7 +3,8 @@ namespace UBS
 {
 	public enum EBuildStepParameterType
 	{
-		None,
+        None,
+        Boolean,
 		String,
 		Dropdown
 	}


### PR DESCRIPTION
Appending/Improve the UBS to support:

-  a command line argument "buildProcessByNames" containing a comma seperated build process name list, which you can use to reconfigure/retarget the actual build collection.
- a boolean build step parameter type ui, which you can use to support simple "true" "false" string scenarios
- some additional common build steps like SetCompileFlags (overwrites the playersettings compile flags) or ClearAllCompilerFlags
- append Android/KeyStorePath step with replaced keywords, which you can use to start from a specific folder