### PR TITLE
Fix build scenes handling

### DIFF
--- a/Editor/EditorWindow/BuildProcessEditor.cs
+++ b/Editor/EditorWindow/BuildProcessEditor.cs
@@ -163,9 +163,6 @@ namespace UBS
 
 		public void OnDestroy()
 		{
-			if (_editedBuildProcess != null)
-				SaveScenesToStringList();
-
 			_editedBuildProcess = null;
 		}
         List<BuildOptions> _buildOptions;
@@ -247,13 +244,9 @@ namespace UBS
 
 			if (pProcess != _editedBuildProcess)
 			{
-				if (_editedBuildProcess != null)
-					SaveScenesToStringList();
-
 				_editedBuildProcess = pProcess;
 				collection = pCollection;
 
-				LoadScenesFromStringList();
 				OnEnable();
 				
 				// after switching to another process, we want to make sure to unfocus all possible controls
@@ -573,13 +566,10 @@ namespace UBS
 
 		private void CopyScenesFromSettings()
 		{
-			_editedBuildProcess.Scenes.Clear();
 			_editedBuildProcess.SceneAssets.Clear();
 			var scenes = EditorBuildSettings.scenes;
 			foreach (var scene in scenes)
 			{
-				var sceneGuid = scene.guid.ToString();
-				_editedBuildProcess.Scenes.Add(sceneGuid);
 				var scenePath = scene.path;
 				AddSceneAssetFromScenePath(scenePath);
 			}
@@ -616,27 +606,6 @@ namespace UBS
 			{
 				Debug.LogError($"Error adding scene with GUID {sceneGuid}");
 				Debug.LogException(exception);
-			}
-		}
-
-		private void SaveScenesToStringList()
-		{
-			_editedBuildProcess.Scenes.Clear();
-
-			foreach (var t in _editedBuildProcess.SceneAssets)
-			{
-				var scenePath = AssetDatabase.GetAssetPath(t);
-				var sceneGuid = AssetDatabase.AssetPathToGUID(scenePath);
-				_editedBuildProcess.Scenes.Add(sceneGuid);
-			}
-		}
-
-		private void LoadScenesFromStringList()
-		{
-			_editedBuildProcess.SceneAssets.Clear();
-			foreach (var sceneGuid in _editedBuildProcess.Scenes)
-			{
-				AddSceneAssetFromSceneGuid(sceneGuid);
 			}
 		}
 

--- a/Editor/UBS/BuildProcess.cs
+++ b/Editor/UBS/BuildProcess.cs
@@ -31,7 +31,6 @@ namespace UBS {
 			Platform = other.Platform;
 			Options = other.Options;
 			Selected = false;
-			Scenes = new List<string>( other.Scenes );
 			SceneAssets = new List<SceneAsset>( other.SceneAssets );
 		}
 
@@ -72,10 +71,6 @@ namespace UBS {
         [field: FormerlySerializedAs("mSelected")]
         [field:SerializeField()]
         public bool Selected { get; set; }
-
-        [field: FormerlySerializedAs("mScenes")]
-        [field:SerializeField()]
-        public List<string> Scenes { get; private set; } = new List<string>();
 
         [field: FormerlySerializedAs("mSceneAssets")]
         [field:SerializeField()]

--- a/Editor/UBS/BuildProcess.cs
+++ b/Editor/UBS/BuildProcess.cs
@@ -31,8 +31,8 @@ namespace UBS {
 			Platform = other.Platform;
 			Options = other.Options;
 			Selected = false;
-			Scenes = new List<string>( other.Scenes.ToArray() );
-			SceneAssets = new List<SceneAsset>( other.SceneAssets.ToArray() );
+			Scenes = new List<string>( other.Scenes );
+			SceneAssets = new List<SceneAsset>( other.SceneAssets );
 		}
 
 		#region data

--- a/Editor/UBS/UBSProcess.cs
+++ b/Editor/UBS/UBSProcess.cs
@@ -471,9 +471,14 @@ namespace UBS
 
 			if (!CurrentProcess.Pretend)
 			{
+				var scenePaths = new string[CurrentProcess.Scenes.Count];
+				for (var index = 0; index < CurrentProcess.Scenes.Count; index++)
+				{
+					scenePaths[index] = AssetDatabase.GUIDToAssetPath(CurrentProcess.Scenes[index]);
+				}
 				BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
 				{
-					scenes = CurrentProcess.Scenes.ToArray(),
+					scenes = scenePaths,
 					locationPathName = CurrentProcess.OutputPath,
 					target = CurrentProcess.Platform,
 					options = bo

--- a/Editor/UBS/UBSProcess.cs
+++ b/Editor/UBS/UBSProcess.cs
@@ -438,11 +438,6 @@ namespace UBS
 
 			if(!CheckOutputPath(CurrentProcess))
 				return;
-            
-			if (!EditorUserBuildSettings.SwitchActiveBuildTarget (Helpers.GroupFromBuildTarget(CurrentProcess.Platform), CurrentProcess.Platform)) {
-                Cancel();
-				throw new Exception("Could not switch to build target: " + CurrentProcess.Platform);
-			}
 
 			_preStepWalker.Init( CurrentProcess.PreBuildSteps, mCurrentBuildConfiguration );
 
@@ -471,16 +466,19 @@ namespace UBS
 		{
             
 			BuildOptions bo = CurrentProcess.Options;
-			if(_buildAndRun)
-				bo = bo | BuildOptions.AutoRunPlayer;
+			if (_buildAndRun)
+				bo |= BuildOptions.AutoRunPlayer;
 
-			if(!CurrentProcess.Pretend)
+			if (!CurrentProcess.Pretend)
 			{
-				BuildReport report = BuildPipeline.BuildPlayer(
-					CurrentProcess.Scenes.ToArray(),
-					CurrentProcess.OutputPath,
-					CurrentProcess.Platform,
-					bo );
+				BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
+				{
+					scenes = CurrentProcess.Scenes.ToArray(),
+					locationPathName = CurrentProcess.OutputPath,
+					target = CurrentProcess.Platform,
+					options = bo
+				};
+				BuildReport report = BuildPipeline.BuildPlayer(buildPlayerOptions);
 				UnityEngine.Debug.Log("Playerbuild Result: " + report.summary.result);
 				if (report.summary.result != BuildResult.Succeeded)
 				{

--- a/Editor/UBS/UBSProcess.cs
+++ b/Editor/UBS/UBSProcess.cs
@@ -443,15 +443,6 @@ namespace UBS
                 Cancel();
 				throw new Exception("Could not switch to build target: " + CurrentProcess.Platform);
 			}
-			
-			var scenes = new EditorBuildSettingsScene[CurrentProcess.Scenes.Count];
-			for(int i = 0;i< scenes.Length;i++)
-			{
-				EditorBuildSettingsScene ebss = new EditorBuildSettingsScene( CurrentProcess.Scenes[i] ,true );
-				scenes[i] = ebss;
-			}
-			EditorBuildSettings.scenes = scenes;
-
 
 			_preStepWalker.Init( CurrentProcess.PreBuildSteps, mCurrentBuildConfiguration );
 
@@ -479,13 +470,6 @@ namespace UBS
 		void DoBuilding()
 		{
             
-			List<string> scenes = new List<string>();
-
-			foreach(var scn in EditorBuildSettings.scenes)
-			{
-				if(scn.enabled)
-					scenes.Add(scn.path);
-			}
 			BuildOptions bo = CurrentProcess.Options;
 			if(_buildAndRun)
 				bo = bo | BuildOptions.AutoRunPlayer;
@@ -493,7 +477,7 @@ namespace UBS
 			if(!CurrentProcess.Pretend)
 			{
 				BuildReport report = BuildPipeline.BuildPlayer(
-					scenes.ToArray(),
+					CurrentProcess.Scenes.ToArray(),
 					CurrentProcess.OutputPath,
 					CurrentProcess.Platform,
 					bo );

--- a/Editor/UBS/UBSProcess.cs
+++ b/Editor/UBS/UBSProcess.cs
@@ -471,14 +471,19 @@ namespace UBS
 
 			if (!CurrentProcess.Pretend)
 			{
-				var scenePaths = new string[CurrentProcess.Scenes.Count];
-				for (var index = 0; index < CurrentProcess.Scenes.Count; index++)
+				var scenePaths = new List<string>();
+				foreach (var sceneAsset in CurrentProcess.SceneAssets)
 				{
-					scenePaths[index] = AssetDatabase.GUIDToAssetPath(CurrentProcess.Scenes[index]);
+					if (ReferenceEquals(null, sceneAsset))
+						continue;
+					var scenePath = AssetDatabase.GetAssetPath(sceneAsset);
+					if (string.IsNullOrEmpty(scenePath))
+						continue;
+					scenePaths.Add(scenePath);
 				}
 				BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
 				{
-					scenes = scenePaths,
+					scenes = scenePaths.ToArray(),
 					locationPathName = CurrentProcess.OutputPath,
 					target = CurrentProcess.Platform,
 					options = bo


### PR DESCRIPTION
do not modify ProjectSettings/EditorBuildSettings.asset
save scenes as GUIDs and not paths (so safe to rename or move), actually no need to save scenes in two separate lists, SceneAssets is enough.